### PR TITLE
add tag account field to xnft

### DIFF
--- a/app/components/Publish/Details.tsx
+++ b/app/components/Publish/Details.tsx
@@ -2,6 +2,7 @@ import { PhotographIcon } from '@heroicons/react/outline';
 import { type KeyboardEvent, memo, useEffect, type FunctionComponent } from 'react';
 import { useDropzone } from 'react-dropzone';
 import type { StepComponentProps } from '../../pages/publish';
+import { XNFT_TAG_OPTIONS } from '../../utils/xnft';
 import SupplySelect from './SupplySelect';
 
 const inputClasses = `focus:border-[#F66C5E] border-[#18181B] bg-[#18181B]
@@ -38,6 +39,7 @@ const Details: FunctionComponent<StepComponentProps> = ({ state, setState, setNe
       state.title,
       state.description,
       state.publisher,
+      state.tag,
       state.website,
       state.supply,
       state.price,
@@ -99,6 +101,29 @@ const Details: FunctionComponent<StepComponentProps> = ({ state, setState, setNe
           value={state.publisher}
           onChange={e => setState(prev => ({ ...prev, publisher: e.target.value }))}
         />
+      </div>
+
+      {/* Tag */}
+      <div>
+        <label htmlFor="tag" className="text-sm font-medium tracking-wide text-[#E5E7EB]">
+          Tag
+        </label>
+        <select
+          required
+          id="tag"
+          name="tag"
+          className={inputClasses}
+          value={state.tag}
+          onChange={e =>
+            setState(prev => ({ ...prev, tag: e.target.value as typeof XNFT_TAG_OPTIONS[number] }))
+          }
+        >
+          {XNFT_TAG_OPTIONS.map((o, idx) => (
+            <option key={idx} value={o}>
+              {o}
+            </option>
+          ))}
+        </select>
       </div>
 
       {/* Website */}

--- a/app/pages/publish.tsx
+++ b/app/pages/publish.tsx
@@ -21,7 +21,7 @@ import {
 import { HashLoader } from 'react-spinners';
 import { useProgram } from '../state/hooks/solana';
 import { uploadFiles, uploadMetadata } from '../utils/s3';
-import xNFT from '../utils/xnft';
+import xNFT, { XNFT_TAG_OPTIONS } from '../utils/xnft';
 
 const BundleUpload = dynamic(() => import('../components/Publish/BundleUpload'));
 const Details = dynamic(() => import('../components/Publish/Details'));
@@ -84,6 +84,7 @@ const defaultUploadState = {
   publisher: '',
   website: '',
   bundle: {} as File,
+  tag: 'None' as typeof XNFT_TAG_OPTIONS[number],
   royalties: '',
   price: '',
   supply: 'inf',

--- a/app/programs/xnft.ts
+++ b/app/programs/xnft.ts
@@ -1,939 +1,1027 @@
 export type Xnft = {
-  version: '0.1.0';
-  name: 'xnft';
-  instructions: [
+  "version": "0.1.0",
+  "name": "xnft",
+  "instructions": [
     {
-      name: 'createXnft';
-      docs: [
-        'Creates all parts of an xNFT instance.',
-        '',
-        '* Master mint (supply 1).',
-        '* Master token.',
-        '* Master metadata PDA associated with the master mint.',
-        '* Master edition PDA associated with the master mint.',
-        '* xNFT PDA associated with the master edition.',
-        '',
-        'Once this is invoked, an xNFT exists and can be "installed" by users.'
-      ];
-      accounts: [
+      "name": "createXnft",
+      "docs": [
+        "Creates all parts of an xNFT instance.",
+        "",
+        "* Master mint (supply 1).",
+        "* Master token.",
+        "* Master metadata PDA associated with the master mint.",
+        "* Master edition PDA associated with the master mint.",
+        "* xNFT PDA associated with the master edition.",
+        "",
+        "Once this is invoked, an xNFT exists and can be \"installed\" by users."
+      ],
+      "accounts": [
         {
-          name: 'metadataProgram';
-          isMut: false;
-          isSigner: false;
+          "name": "metadataProgram",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: 'masterMint';
-          isMut: true;
-          isSigner: false;
-          pda: {
-            seeds: [
+          "name": "masterMint",
+          "isMut": true,
+          "isSigner": false,
+          "pda": {
+            "seeds": [
               {
-                kind: 'const';
-                type: 'string';
-                value: 'mint';
+                "kind": "const",
+                "type": "string",
+                "value": "mint"
               },
               {
-                kind: 'account';
-                type: 'publicKey';
-                path: 'publisher';
+                "kind": "account",
+                "type": "publicKey",
+                "path": "publisher"
               },
               {
-                kind: 'arg';
-                type: 'string';
-                path: 'name';
+                "kind": "arg",
+                "type": "string",
+                "path": "name"
               }
-            ];
-          };
-        },
-        {
-          name: 'masterToken';
-          isMut: true;
-          isSigner: false;
-          pda: {
-            seeds: [
-              {
-                kind: 'const';
-                type: 'string';
-                value: 'token';
-              },
-              {
-                kind: 'account';
-                type: 'publicKey';
-                account: 'Mint';
-                path: 'master_mint';
-              }
-            ];
-          };
-        },
-        {
-          name: 'masterMetadata';
-          isMut: true;
-          isSigner: false;
-          docs: ['metadata program.'];
-          pda: {
-            seeds: [
-              {
-                kind: 'const';
-                type: 'string';
-                value: 'metadata';
-              },
-              {
-                kind: 'account';
-                type: 'publicKey';
-                path: 'metadata_program';
-              },
-              {
-                kind: 'account';
-                type: 'publicKey';
-                account: 'Mint';
-                path: 'master_mint';
-              }
-            ];
-            programId: {
-              kind: 'account';
-              type: 'publicKey';
-              path: 'metadata_program';
-            };
-          };
-        },
-        {
-          name: 'masterEdition';
-          isMut: true;
-          isSigner: false;
-          docs: ['metadata program.'];
-          pda: {
-            seeds: [
-              {
-                kind: 'const';
-                type: 'string';
-                value: 'metadata';
-              },
-              {
-                kind: 'account';
-                type: 'publicKey';
-                path: 'metadata_program';
-              },
-              {
-                kind: 'account';
-                type: 'publicKey';
-                account: 'Mint';
-                path: 'master_mint';
-              },
-              {
-                kind: 'const';
-                type: 'string';
-                value: 'edition';
-              }
-            ];
-            programId: {
-              kind: 'account';
-              type: 'publicKey';
-              path: 'metadata_program';
-            };
-          };
-        },
-        {
-          name: 'xnft';
-          isMut: true;
-          isSigner: false;
-          pda: {
-            seeds: [
-              {
-                kind: 'const';
-                type: 'string';
-                value: 'xnft';
-              },
-              {
-                kind: 'account';
-                type: 'publicKey';
-                path: 'master_edition';
-              }
-            ];
-          };
-        },
-        {
-          name: 'payer';
-          isMut: true;
-          isSigner: true;
-        },
-        {
-          name: 'publisher';
-          isMut: false;
-          isSigner: true;
-        },
-        {
-          name: 'rent';
-          isMut: false;
-          isSigner: false;
-        },
-        {
-          name: 'systemProgram';
-          isMut: false;
-          isSigner: false;
-        },
-        {
-          name: 'tokenProgram';
-          isMut: false;
-          isSigner: false;
-        }
-      ];
-      args: [
-        {
-          name: 'name';
-          type: 'string';
-        },
-        {
-          name: 'symbol';
-          type: 'string';
-        },
-        {
-          name: 'uri';
-          type: 'string';
-        },
-        {
-          name: 'sellerFeeBasisPoints';
-          type: 'u16';
-        },
-        {
-          name: 'installPrice';
-          type: 'u64';
-        },
-        {
-          name: 'installVault';
-          type: 'publicKey';
-        }
-      ];
-    },
-    {
-      name: 'updateXnft';
-      docs: ['Updates the code of an xNFT.', '', 'This is simply a token metadata update cpi.'];
-      accounts: [];
-      args: [];
-    },
-    {
-      name: 'createInstall';
-      docs: [
-        'Creates an "installation" of an xNFT.',
-        '',
-        'Installation is just a synonym for minting an xNFT edition for a given',
-        'user.'
-      ];
-      accounts: [
-        {
-          name: 'xnft';
-          isMut: true;
-          isSigner: false;
-        },
-        {
-          name: 'install';
-          isMut: true;
-          isSigner: false;
-          pda: {
-            seeds: [
-              {
-                kind: 'const';
-                type: 'string';
-                value: 'install';
-              },
-              {
-                kind: 'account';
-                type: 'publicKey';
-                path: 'authority';
-              },
-              {
-                kind: 'account';
-                type: 'publicKey';
-                account: 'Xnft2';
-                path: 'xnft';
-              }
-            ];
-          };
-        },
-        {
-          name: 'installVault';
-          isMut: false;
-          isSigner: false;
-        },
-        {
-          name: 'authority';
-          isMut: true;
-          isSigner: true;
-        },
-        {
-          name: 'systemProgram';
-          isMut: false;
-          isSigner: false;
-        }
-      ];
-      args: [];
-    },
-    {
-      name: 'createInstallWithAuthority';
-      docs: [
-        'Variant of `create_xnft_installation` where the install authority is',
-        'required to sign.'
-      ];
-      accounts: [
-        {
-          name: 'xnft';
-          isMut: true;
-          isSigner: false;
-        },
-        {
-          name: 'install';
-          isMut: true;
-          isSigner: false;
-          pda: {
-            seeds: [
-              {
-                kind: 'const';
-                type: 'string';
-                value: 'install';
-              },
-              {
-                kind: 'account';
-                type: 'publicKey';
-                path: 'authority';
-              }
-            ];
-          };
-        },
-        {
-          name: 'authority';
-          isMut: true;
-          isSigner: true;
-        },
-        {
-          name: 'installAuthority';
-          isMut: false;
-          isSigner: true;
-        },
-        {
-          name: 'systemProgram';
-          isMut: false;
-          isSigner: false;
-        }
-      ];
-      args: [];
-    },
-    {
-      name: 'deleteInstall';
-      docs: ['Closes the install account.'];
-      accounts: [];
-      args: [];
-    },
-    {
-      name: 'setSuspended';
-      docs: ['Sets the install suspension flag on the xnft.'];
-      accounts: [
-        {
-          name: 'xnft';
-          isMut: true;
-          isSigner: false;
-        },
-        {
-          name: 'authority';
-          isMut: false;
-          isSigner: true;
-        }
-      ];
-      args: [
-        {
-          name: 'flag';
-          type: 'bool';
-        }
-      ];
-    }
-  ];
-  accounts: [
-    {
-      name: 'xnft2';
-      type: {
-        kind: 'struct';
-        fields: [
-          {
-            name: 'authority';
-            type: 'publicKey';
-          },
-          {
-            name: 'publisher';
-            type: 'publicKey';
-          },
-          {
-            name: 'kind';
-            type: {
-              defined: 'Kind';
-            };
-          },
-          {
-            name: 'totalInstalls';
-            type: 'u64';
-          },
-          {
-            name: 'installPrice';
-            type: 'u64';
-          },
-          {
-            name: 'installVault';
-            type: 'publicKey';
-          },
-          {
-            name: 'masterEdition';
-            type: 'publicKey';
-          },
-          {
-            name: 'masterMetadata';
-            type: 'publicKey';
-          },
-          {
-            name: 'masterMint';
-            type: 'publicKey';
-          },
-          {
-            name: 'bump';
-            type: 'u8';
-          },
-          {
-            name: 'createdTs';
-            type: 'i64';
-          },
-          {
-            name: 'updatedTs';
-            type: 'i64';
-          },
-          {
-            name: 'installAuthority';
-            type: {
-              option: 'publicKey';
-            };
-          },
-          {
-            name: 'name';
-            type: 'string';
-          },
-          {
-            name: 'suspended';
-            type: 'bool';
+            ]
           }
-        ];
-      };
+        },
+        {
+          "name": "masterToken",
+          "isMut": true,
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "token"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Mint",
+                "path": "master_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "masterMetadata",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "metadata program."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "metadata"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "metadata_program"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Mint",
+                "path": "master_mint"
+              }
+            ],
+            "programId": {
+              "kind": "account",
+              "type": "publicKey",
+              "path": "metadata_program"
+            }
+          }
+        },
+        {
+          "name": "masterEdition",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "metadata program."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "metadata"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "metadata_program"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Mint",
+                "path": "master_mint"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "edition"
+              }
+            ],
+            "programId": {
+              "kind": "account",
+              "type": "publicKey",
+              "path": "metadata_program"
+            }
+          }
+        },
+        {
+          "name": "xnft",
+          "isMut": true,
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "xnft"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "master_edition"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "publisher",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "symbol",
+          "type": "string"
+        },
+        {
+          "name": "tag",
+          "type": {
+            "defined": "Tag"
+          }
+        },
+        {
+          "name": "uri",
+          "type": "string"
+        },
+        {
+          "name": "sellerFeeBasisPoints",
+          "type": "u16"
+        },
+        {
+          "name": "installPrice",
+          "type": "u64"
+        },
+        {
+          "name": "installVault",
+          "type": "publicKey"
+        }
+      ]
     },
     {
-      name: 'install';
-      type: {
-        kind: 'struct';
-        fields: [
-          {
-            name: 'authority';
-            type: 'publicKey';
-          },
-          {
-            name: 'xnft';
-            type: 'publicKey';
-          },
-          {
-            name: 'id';
-            type: 'u64';
-          },
-          {
-            name: 'masterMetadata';
-            type: 'publicKey';
-          }
-        ];
-      };
-    }
-  ];
-  types: [
+      "name": "updateXnft",
+      "docs": [
+        "Updates the code of an xNFT.",
+        "",
+        "This is simply a token metadata update cpi."
+      ],
+      "accounts": [],
+      "args": []
+    },
     {
-      name: 'Kind';
-      type: {
-        kind: 'enum';
-        variants: [
+      "name": "createInstall",
+      "docs": [
+        "Creates an \"installation\" of an xNFT.",
+        "",
+        "Installation is just a synonym for minting an xNFT edition for a given",
+        "user."
+      ],
+      "accounts": [
+        {
+          "name": "xnft",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "install",
+          "isMut": true,
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "install"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "authority"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Xnft2",
+                "path": "xnft"
+              }
+            ]
+          }
+        },
+        {
+          "name": "installVault",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "createInstallWithAuthority",
+      "docs": [
+        "Variant of `create_xnft_installation` where the install authority is",
+        "required to sign."
+      ],
+      "accounts": [
+        {
+          "name": "xnft",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "install",
+          "isMut": true,
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "install"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "installAuthority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "deleteInstall",
+      "docs": [
+        "Closes the install account."
+      ],
+      "accounts": [],
+      "args": []
+    },
+    {
+      "name": "setSuspended",
+      "docs": [
+        "Sets the install suspension flag on the xnft."
+      ],
+      "accounts": [
+        {
+          "name": "xnft",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "flag",
+          "type": "bool"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "xnft2",
+      "type": {
+        "kind": "struct",
+        "fields": [
           {
-            name: 'Table';
+            "name": "authority",
+            "type": "publicKey"
           },
           {
-            name: 'Image';
+            "name": "publisher",
+            "type": "publicKey"
+          },
+          {
+            "name": "kind",
+            "type": {
+              "defined": "Kind"
+            }
+          },
+          {
+            "name": "totalInstalls",
+            "type": "u64"
+          },
+          {
+            "name": "installPrice",
+            "type": "u64"
+          },
+          {
+            "name": "installVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "masterEdition",
+            "type": "publicKey"
+          },
+          {
+            "name": "masterMetadata",
+            "type": "publicKey"
+          },
+          {
+            "name": "masterMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "createdTs",
+            "type": "i64"
+          },
+          {
+            "name": "updatedTs",
+            "type": "i64"
+          },
+          {
+            "name": "installAuthority",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "suspended",
+            "type": "bool"
+          },
+          {
+            "name": "tag",
+            "type": {
+              "defined": "Tag"
+            }
           }
-        ];
-      };
-    }
-  ];
-  errors: [
+        ]
+      }
+    },
     {
-      code: 6000;
-      name: 'SuspendedInstallation';
-      msg: 'Attempting to install a currently suspended xNFT';
+      "name": "install",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "xnft",
+            "type": "publicKey"
+          },
+          {
+            "name": "id",
+            "type": "u64"
+          },
+          {
+            "name": "masterMetadata",
+            "type": "publicKey"
+          }
+        ]
+      }
     }
-  ];
+  ],
+  "types": [
+    {
+      "name": "Kind",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Table"
+          },
+          {
+            "name": "Image"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Tag",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Defi"
+          },
+          {
+            "name": "Game"
+          },
+          {
+            "name": "Nft"
+          },
+          {
+            "name": "None"
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "SuspendedInstallation",
+      "msg": "Attempting to install a currently suspended xNFT"
+    }
+  ]
 };
 
 export const IDL: Xnft = {
-  version: '0.1.0',
-  name: 'xnft',
-  instructions: [
+  "version": "0.1.0",
+  "name": "xnft",
+  "instructions": [
     {
-      name: 'createXnft',
-      docs: [
-        'Creates all parts of an xNFT instance.',
-        '',
-        '* Master mint (supply 1).',
-        '* Master token.',
-        '* Master metadata PDA associated with the master mint.',
-        '* Master edition PDA associated with the master mint.',
-        '* xNFT PDA associated with the master edition.',
-        '',
-        'Once this is invoked, an xNFT exists and can be "installed" by users.'
+      "name": "createXnft",
+      "docs": [
+        "Creates all parts of an xNFT instance.",
+        "",
+        "* Master mint (supply 1).",
+        "* Master token.",
+        "* Master metadata PDA associated with the master mint.",
+        "* Master edition PDA associated with the master mint.",
+        "* xNFT PDA associated with the master edition.",
+        "",
+        "Once this is invoked, an xNFT exists and can be \"installed\" by users."
       ],
-      accounts: [
+      "accounts": [
         {
-          name: 'metadataProgram',
-          isMut: false,
-          isSigner: false
+          "name": "metadataProgram",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: 'masterMint',
-          isMut: true,
-          isSigner: false,
-          pda: {
-            seeds: [
+          "name": "masterMint",
+          "isMut": true,
+          "isSigner": false,
+          "pda": {
+            "seeds": [
               {
-                kind: 'const',
-                type: 'string',
-                value: 'mint'
+                "kind": "const",
+                "type": "string",
+                "value": "mint"
               },
               {
-                kind: 'account',
-                type: 'publicKey',
-                path: 'publisher'
+                "kind": "account",
+                "type": "publicKey",
+                "path": "publisher"
               },
               {
-                kind: 'arg',
-                type: 'string',
-                path: 'name'
+                "kind": "arg",
+                "type": "string",
+                "path": "name"
               }
             ]
           }
         },
         {
-          name: 'masterToken',
-          isMut: true,
-          isSigner: false,
-          pda: {
-            seeds: [
+          "name": "masterToken",
+          "isMut": true,
+          "isSigner": false,
+          "pda": {
+            "seeds": [
               {
-                kind: 'const',
-                type: 'string',
-                value: 'token'
+                "kind": "const",
+                "type": "string",
+                "value": "token"
               },
               {
-                kind: 'account',
-                type: 'publicKey',
-                account: 'Mint',
-                path: 'master_mint'
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Mint",
+                "path": "master_mint"
               }
             ]
           }
         },
         {
-          name: 'masterMetadata',
-          isMut: true,
-          isSigner: false,
-          docs: ['metadata program.'],
-          pda: {
-            seeds: [
+          "name": "masterMetadata",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "metadata program."
+          ],
+          "pda": {
+            "seeds": [
               {
-                kind: 'const',
-                type: 'string',
-                value: 'metadata'
+                "kind": "const",
+                "type": "string",
+                "value": "metadata"
               },
               {
-                kind: 'account',
-                type: 'publicKey',
-                path: 'metadata_program'
+                "kind": "account",
+                "type": "publicKey",
+                "path": "metadata_program"
               },
               {
-                kind: 'account',
-                type: 'publicKey',
-                account: 'Mint',
-                path: 'master_mint'
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Mint",
+                "path": "master_mint"
               }
             ],
-            programId: {
-              kind: 'account',
-              type: 'publicKey',
-              path: 'metadata_program'
+            "programId": {
+              "kind": "account",
+              "type": "publicKey",
+              "path": "metadata_program"
             }
           }
         },
         {
-          name: 'masterEdition',
-          isMut: true,
-          isSigner: false,
-          docs: ['metadata program.'],
-          pda: {
-            seeds: [
+          "name": "masterEdition",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "metadata program."
+          ],
+          "pda": {
+            "seeds": [
               {
-                kind: 'const',
-                type: 'string',
-                value: 'metadata'
+                "kind": "const",
+                "type": "string",
+                "value": "metadata"
               },
               {
-                kind: 'account',
-                type: 'publicKey',
-                path: 'metadata_program'
+                "kind": "account",
+                "type": "publicKey",
+                "path": "metadata_program"
               },
               {
-                kind: 'account',
-                type: 'publicKey',
-                account: 'Mint',
-                path: 'master_mint'
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Mint",
+                "path": "master_mint"
               },
               {
-                kind: 'const',
-                type: 'string',
-                value: 'edition'
+                "kind": "const",
+                "type": "string",
+                "value": "edition"
               }
             ],
-            programId: {
-              kind: 'account',
-              type: 'publicKey',
-              path: 'metadata_program'
+            "programId": {
+              "kind": "account",
+              "type": "publicKey",
+              "path": "metadata_program"
             }
           }
         },
         {
-          name: 'xnft',
-          isMut: true,
-          isSigner: false,
-          pda: {
-            seeds: [
+          "name": "xnft",
+          "isMut": true,
+          "isSigner": false,
+          "pda": {
+            "seeds": [
               {
-                kind: 'const',
-                type: 'string',
-                value: 'xnft'
+                "kind": "const",
+                "type": "string",
+                "value": "xnft"
               },
               {
-                kind: 'account',
-                type: 'publicKey',
-                path: 'master_edition'
+                "kind": "account",
+                "type": "publicKey",
+                "path": "master_edition"
               }
             ]
           }
         },
         {
-          name: 'payer',
-          isMut: true,
-          isSigner: true
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
         },
         {
-          name: 'publisher',
-          isMut: false,
-          isSigner: true
+          "name": "publisher",
+          "isMut": false,
+          "isSigner": true
         },
         {
-          name: 'rent',
-          isMut: false,
-          isSigner: false
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: 'systemProgram',
-          isMut: false,
-          isSigner: false
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: 'tokenProgram',
-          isMut: false,
-          isSigner: false
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
         }
       ],
-      args: [
+      "args": [
         {
-          name: 'name',
-          type: 'string'
+          "name": "name",
+          "type": "string"
         },
         {
-          name: 'symbol',
-          type: 'string'
+          "name": "symbol",
+          "type": "string"
         },
         {
-          name: 'uri',
-          type: 'string'
+          "name": "tag",
+          "type": {
+            "defined": "Tag"
+          }
         },
         {
-          name: 'sellerFeeBasisPoints',
-          type: 'u16'
+          "name": "uri",
+          "type": "string"
         },
         {
-          name: 'installPrice',
-          type: 'u64'
+          "name": "sellerFeeBasisPoints",
+          "type": "u16"
         },
         {
-          name: 'installVault',
-          type: 'publicKey'
+          "name": "installPrice",
+          "type": "u64"
+        },
+        {
+          "name": "installVault",
+          "type": "publicKey"
         }
       ]
     },
     {
-      name: 'updateXnft',
-      docs: ['Updates the code of an xNFT.', '', 'This is simply a token metadata update cpi.'],
-      accounts: [],
-      args: []
+      "name": "updateXnft",
+      "docs": [
+        "Updates the code of an xNFT.",
+        "",
+        "This is simply a token metadata update cpi."
+      ],
+      "accounts": [],
+      "args": []
     },
     {
-      name: 'createInstall',
-      docs: [
-        'Creates an "installation" of an xNFT.',
-        '',
-        'Installation is just a synonym for minting an xNFT edition for a given',
-        'user.'
+      "name": "createInstall",
+      "docs": [
+        "Creates an \"installation\" of an xNFT.",
+        "",
+        "Installation is just a synonym for minting an xNFT edition for a given",
+        "user."
       ],
-      accounts: [
+      "accounts": [
         {
-          name: 'xnft',
-          isMut: true,
-          isSigner: false
+          "name": "xnft",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: 'install',
-          isMut: true,
-          isSigner: false,
-          pda: {
-            seeds: [
+          "name": "install",
+          "isMut": true,
+          "isSigner": false,
+          "pda": {
+            "seeds": [
               {
-                kind: 'const',
-                type: 'string',
-                value: 'install'
+                "kind": "const",
+                "type": "string",
+                "value": "install"
               },
               {
-                kind: 'account',
-                type: 'publicKey',
-                path: 'authority'
+                "kind": "account",
+                "type": "publicKey",
+                "path": "authority"
               },
               {
-                kind: 'account',
-                type: 'publicKey',
-                account: 'Xnft2',
-                path: 'xnft'
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Xnft2",
+                "path": "xnft"
               }
             ]
           }
         },
         {
-          name: 'installVault',
-          isMut: false,
-          isSigner: false
+          "name": "installVault",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: 'authority',
-          isMut: true,
-          isSigner: true
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
         },
         {
-          name: 'systemProgram',
-          isMut: false,
-          isSigner: false
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         }
       ],
-      args: []
+      "args": []
     },
     {
-      name: 'createInstallWithAuthority',
-      docs: [
-        'Variant of `create_xnft_installation` where the install authority is',
-        'required to sign.'
+      "name": "createInstallWithAuthority",
+      "docs": [
+        "Variant of `create_xnft_installation` where the install authority is",
+        "required to sign."
       ],
-      accounts: [
+      "accounts": [
         {
-          name: 'xnft',
-          isMut: true,
-          isSigner: false
+          "name": "xnft",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: 'install',
-          isMut: true,
-          isSigner: false,
-          pda: {
-            seeds: [
+          "name": "install",
+          "isMut": true,
+          "isSigner": false,
+          "pda": {
+            "seeds": [
               {
-                kind: 'const',
-                type: 'string',
-                value: 'install'
+                "kind": "const",
+                "type": "string",
+                "value": "install"
               },
               {
-                kind: 'account',
-                type: 'publicKey',
-                path: 'authority'
+                "kind": "account",
+                "type": "publicKey",
+                "path": "authority"
               }
             ]
           }
         },
         {
-          name: 'authority',
-          isMut: true,
-          isSigner: true
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
         },
         {
-          name: 'installAuthority',
-          isMut: false,
-          isSigner: true
+          "name": "installAuthority",
+          "isMut": false,
+          "isSigner": true
         },
         {
-          name: 'systemProgram',
-          isMut: false,
-          isSigner: false
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         }
       ],
-      args: []
+      "args": []
     },
     {
-      name: 'deleteInstall',
-      docs: ['Closes the install account.'],
-      accounts: [],
-      args: []
+      "name": "deleteInstall",
+      "docs": [
+        "Closes the install account."
+      ],
+      "accounts": [],
+      "args": []
     },
     {
-      name: 'setSuspended',
-      docs: ['Sets the install suspension flag on the xnft.'],
-      accounts: [
+      "name": "setSuspended",
+      "docs": [
+        "Sets the install suspension flag on the xnft."
+      ],
+      "accounts": [
         {
-          name: 'xnft',
-          isMut: true,
-          isSigner: false
+          "name": "xnft",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: 'authority',
-          isMut: false,
-          isSigner: true
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
         }
       ],
-      args: [
+      "args": [
         {
-          name: 'flag',
-          type: 'bool'
+          "name": "flag",
+          "type": "bool"
         }
       ]
     }
   ],
-  accounts: [
+  "accounts": [
     {
-      name: 'xnft2',
-      type: {
-        kind: 'struct',
-        fields: [
+      "name": "xnft2",
+      "type": {
+        "kind": "struct",
+        "fields": [
           {
-            name: 'authority',
-            type: 'publicKey'
+            "name": "authority",
+            "type": "publicKey"
           },
           {
-            name: 'publisher',
-            type: 'publicKey'
+            "name": "publisher",
+            "type": "publicKey"
           },
           {
-            name: 'kind',
-            type: {
-              defined: 'Kind'
+            "name": "kind",
+            "type": {
+              "defined": "Kind"
             }
           },
           {
-            name: 'totalInstalls',
-            type: 'u64'
+            "name": "totalInstalls",
+            "type": "u64"
           },
           {
-            name: 'installPrice',
-            type: 'u64'
+            "name": "installPrice",
+            "type": "u64"
           },
           {
-            name: 'installVault',
-            type: 'publicKey'
+            "name": "installVault",
+            "type": "publicKey"
           },
           {
-            name: 'masterEdition',
-            type: 'publicKey'
+            "name": "masterEdition",
+            "type": "publicKey"
           },
           {
-            name: 'masterMetadata',
-            type: 'publicKey'
+            "name": "masterMetadata",
+            "type": "publicKey"
           },
           {
-            name: 'masterMint',
-            type: 'publicKey'
+            "name": "masterMint",
+            "type": "publicKey"
           },
           {
-            name: 'bump',
-            type: 'u8'
+            "name": "bump",
+            "type": "u8"
           },
           {
-            name: 'createdTs',
-            type: 'i64'
+            "name": "createdTs",
+            "type": "i64"
           },
           {
-            name: 'updatedTs',
-            type: 'i64'
+            "name": "updatedTs",
+            "type": "i64"
           },
           {
-            name: 'installAuthority',
-            type: {
-              option: 'publicKey'
+            "name": "installAuthority",
+            "type": {
+              "option": "publicKey"
             }
           },
           {
-            name: 'name',
-            type: 'string'
+            "name": "name",
+            "type": "string"
           },
           {
-            name: 'suspended',
-            type: 'bool'
+            "name": "suspended",
+            "type": "bool"
+          },
+          {
+            "name": "tag",
+            "type": {
+              "defined": "Tag"
+            }
           }
         ]
       }
     },
     {
-      name: 'install',
-      type: {
-        kind: 'struct',
-        fields: [
+      "name": "install",
+      "type": {
+        "kind": "struct",
+        "fields": [
           {
-            name: 'authority',
-            type: 'publicKey'
+            "name": "authority",
+            "type": "publicKey"
           },
           {
-            name: 'xnft',
-            type: 'publicKey'
+            "name": "xnft",
+            "type": "publicKey"
           },
           {
-            name: 'id',
-            type: 'u64'
+            "name": "id",
+            "type": "u64"
           },
           {
-            name: 'masterMetadata',
-            type: 'publicKey'
+            "name": "masterMetadata",
+            "type": "publicKey"
           }
         ]
       }
     }
   ],
-  types: [
+  "types": [
     {
-      name: 'Kind',
-      type: {
-        kind: 'enum',
-        variants: [
+      "name": "Kind",
+      "type": {
+        "kind": "enum",
+        "variants": [
           {
-            name: 'Table'
+            "name": "Table"
           },
           {
-            name: 'Image'
+            "name": "Image"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Tag",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Defi"
+          },
+          {
+            "name": "Game"
+          },
+          {
+            "name": "Nft"
+          },
+          {
+            "name": "None"
           }
         ]
       }
     }
   ],
-  errors: [
+  "errors": [
     {
-      code: 6000,
-      name: 'SuspendedInstallation',
-      msg: 'Attempting to install a currently suspended xNFT'
+      "code": 6000,
+      "name": "SuspendedInstallation",
+      "msg": "Attempting to install a currently suspended xNFT"
     }
   ]
 };

--- a/app/utils/xnft.ts
+++ b/app/utils/xnft.ts
@@ -39,6 +39,8 @@ export type XnftWithMetadata = {
 
 export const XNFT_PROGRAM_ID = new PublicKey(process.env.NEXT_PUBLIC_XNFT_PROGRAMID);
 
+export const XNFT_TAG_OPTIONS = IDL.types[1].type.variants.map(v => v.name);
+
 const anonymousProgram: Program<IDLType> = new Program(
   IDL,
   XNFT_PROGRAM_ID,
@@ -64,6 +66,7 @@ export default abstract class xNFT {
       .createXnft(
         details.title,
         details.title.slice(0, 3).toUpperCase(),
+        { [details.tag.toLowerCase()]: {} },
         `${BUCKET_URL}/${getMetadataPath(xnft)}`,
         parseInt(details.royalties) * 100,
         new BN(details.price),

--- a/programs/xnft/src/lib.rs
+++ b/programs/xnft/src/lib.rs
@@ -432,7 +432,7 @@ pub struct Install {
 }
 
 impl Install {
-    pub const LEN: usize = 8 + 32 + 32 + 8 + 8 + 32;
+    pub const LEN: usize = 8 + 32 + 32 + 8 + 8 + 32; // TODO:FIXME: needs to be recalculated
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
@@ -446,6 +446,7 @@ pub enum Tag {
     Defi,
     Game,
     Nft,
+    None,
 }
 
 impl Xnft2 {

--- a/tests/xnft.ts
+++ b/tests/xnft.ts
@@ -2,7 +2,7 @@ import { PublicKey } from '@solana/web3.js';
 import * as anchor from '@project-serum/anchor';
 import { Program } from '@project-serum/anchor';
 import { assert } from 'chai';
-import { Xnft } from '../target/types/xnft';
+import { IDL, Xnft } from '../target/types/xnft';
 
 const metadataProgram = new PublicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s');
 


### PR DESCRIPTION
closes #34 

- adds `Tag` enum field to `xnft` account data
- desired tag is passed as an ix arg
- adds select input to publish flow in webapp for changing the tag or the new xnft