### PR TITLE
new `create_authority` ix and use control authority account for mint and metadata

### DIFF
--- a/programs/xnft/src/instructions/create_xnft.rs
+++ b/programs/xnft/src/instructions/create_xnft.rs
@@ -34,7 +34,7 @@ pub struct CreateXnft<'info> {
             master_mint.key().as_ref(),
         ],
         bump,
-        token::authority = xnft,
+        token::authority = publisher,
         token::mint = master_mint,
     )]
     pub master_token: Account<'info, TokenAccount>,


### PR DESCRIPTION
@armaniferrante lmk if this is along the lines of what we discussed in slack wrt a global xnft authority in the contract.