### PR TITLE
Fix curator mismatch test

### DIFF
--- a/tests/xnft.spec.ts
+++ b/tests/xnft.spec.ts
@@ -131,7 +131,10 @@ describe("A standard xNFT", () => {
       try {
         await client.verify(xnft);
         assert.ok(false);
-      } catch (_err) {}
+      } catch (err) {
+        const e = err as anchor.AnchorError;
+        assert.strictEqual(e.error.errorCode.code, "CuratorMismatch");
+      }
     });
 
     it("if the curator authority signs the transaction", async () => {


### PR DESCRIPTION
If I understand correctly, the "unless the signer does not match the curator authority" test tries to verify that a call to `verify` fails.

However, if the call succeeds, the subsequent `assert.ok(false)` is caught and the test still passes.

This PR revises the test to use the same approach as the "unless the xNFT is suspended" test: https://github.com/coral-xyz/xnft/blob/1f01ea2e6cd5ab38319d018c50fb8e7359ece5c1/tests/xnft.spec.ts#L168-L173